### PR TITLE
Minor return edits to securitypolicyset_to_name_dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ MIT
 #### Version
 Version | Changes
 ------- | --------
+**1.2.3**| Fixed minor return issue
 **1.2.2**| Add support for Spoke Clusters
 **1.2.1**| Add support for SDK >= 5.1.1b1
 **1.2.0**| Add reverse lookup support (name -> ID) to all functions. Reverse lookup has limitations as names are not unique.

--- a/cloudgenix_idname/__init__.py
+++ b/cloudgenix_idname/__init__.py
@@ -366,7 +366,7 @@ def securitypolicyset_to_name_dict(sdk):
 
     if not status or not securitypolicyset_list:
         logger.info("ERROR: unable to get securitypolicysets for account '{0}'.".format(sdk.tenant_name))
-        return xlate_dict, id_list
+        return xlate_dict, reverse_xlate_dict, id_list
 
     # build translation dict
     for securitypolicyset in securitypolicyset_list:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = cloudgenix_idname
 description = ID -> Name translator for the CloudGenix Python SDK
-version = 1.2.2
+version = 1.2.3
 author = Aaron Edwards
 author-email = cloudgenix_idname@ebob9.com
 description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='cloudgenix_idname',
-      version='1.2.2',
+      version='1.2.3',
       description='ID -> Name translator for the CloudGenix Python SDK',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
cloudgenix_idname utility would crash when no securitypolicy set is configured on the tenant as the reverse_xlate_dict was not being returned. Added minor change to function securitypolicyset_to_name_dict

Changed version to 1.2.3